### PR TITLE
Clean up docs copy and links

### DIFF
--- a/content/_snippets/_app-usage-example.mdx
+++ b/content/_snippets/_app-usage-example.mdx
@@ -1,6 +1,6 @@
 import { Callout } from 'fumadocs-ui/components/callout';
 
-In the example below, our app uses `my-app.js` to add custom funcationality on the storefront that should be loaded on every page of the store.
+In the example below, our app uses `my-app.js` to add custom functionality on the storefront that should be loaded on every page of the store.
 
 
 ```shell title="Example App Structure"
@@ -12,17 +12,17 @@ your-app
  └── manifest.json
 ```
 
-In order to add `my-app.js` to every page of the store, we'll add it to a snippet that uses the `app_asset_url` tag to reference the file source in a script tag.
+To add `my-app.js` to every page of the store, add it to a snippet that uses the `app_asset_url` tag to reference the file source in a script tag.
 
 
 ```django title="Example Asset Usage in Snippet"
-<script src=="{% app_asset_url 'assets/my-app.js' %}"></script>
+<script src="{% app_asset_url 'assets/my-app.js' %}"></script>
 ```
 
 <Callout type="warn">
-All assets are loaded from a CDN which does not support local file imports from another file. It's a best practice to compile and minify your assets into self contained single files.
+All assets are loaded from a CDN, which does not support local file imports from another file. It's best to compile and minify your assets into self-contained files.
 </Callout>
-In order to configure the snippet to load into a theme `app_hook` we'll add it to the app manifest `locations:storefront` configured with the desired location.
+To configure the snippet to load into a theme `app_hook`, add it to the app manifest `locations:storefront` with the desired location.
 
 ```json title="Example Manifest.json"
 {
@@ -34,4 +34,4 @@ In order to configure the snippet to load into a theme `app_hook` we'll add it t
 }
 ```
 
-Once you've done this, you should now see that `my-app.js` is being loaded on every page on the storefront globally in the footer. :clap:
+Once you've done this, you should see `my-app.js` loading on every storefront page in the footer. :clap:

--- a/content/_snippets/_offer-development-store.mdx
+++ b/content/_snippets/_offer-development-store.mdx
@@ -2,5 +2,5 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 <Callout type="idea">
 If you need a development store for your app, submit a development store request below and we'll hook you up.
-<a href="https://forms.gle/wzLw4HZ7PxyToh1q6">Request a Development Store</a>
+<a href="https://forms.nextcommerce.com/r/create">Request a Development Store</a>
 </Callout>

--- a/content/docs/admin-api/index.mdx
+++ b/content/docs/admin-api/index.mdx
@@ -7,20 +7,20 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 ### Getting Started
 
-At the core of Next Commerce is the Admin API, developers can manage store resources, integrate third-party services and build seamless external order flows.
+At the core of Next Commerce, the Admin API lets developers manage store resources, integrate third-party services, and build seamless external order flows.
 
 
 ### Authentication
 
-The Admin API uses Oauth 2 authorization protocol to manage access to your store's resources. Oauth Apps (and associated access tokens) can be tailored with object-level permission to ensure that each integrated service only has access to necessary objects.
+The Admin API uses the OAuth 2 authorization protocol to manage access to your store's resources. OAuth apps and associated access tokens can be tailored with object-level permissions to ensure that each integrated service only has access to the objects it needs.
 
-Before using the Admin API, you'll need to create a store and create an OAuth App necessary for API access. To create an OAuth App, navigate to **Settings > API Access** and create a new Oauth App with applicable [permissions](/docs/admin-api/permissions) to retrieve your **Access Token**.  It is recommended to create unique Oauth Apps per external system so that you can revoke as needed.
+Before using the Admin API, you'll need to create a store and an OAuth app for API access. To create an OAuth app, navigate to **Settings > API Access** and create a new OAuth app with the applicable [permissions](/docs/admin-api/permissions) to retrieve your **Access Token**. It is recommended to create unique OAuth apps for each external system so you can revoke access as needed.
 
 ```shell title="Admin API Path"
 https://{store}.29next.store/api/admin/
 ```
 
-**Use your Oauth App Access Token in the request headers to access the API.**
+**Use your OAuth app access token in the request headers to access the API.**
 
 ```shell title="Example Request"
 curl -X GET "https://{store}.29next.store/api/admin/" \
@@ -64,4 +64,4 @@ Admin APIs are rate-limited to maintain the stability and equity of our platform
 <Callout type="info">
 Once you reach API rate limits you'll then receive a 429 Too Many Requests response, and a message that a throttle has been applied.
 </Callout>
-We recommend API users to appropriately limit calls, cache results, and retry requests using strategies that are considered industry best practices,to avoid hitting getting rate limit errors
+We recommend that API users limit calls appropriately, cache results, and retry requests using industry best practices to avoid rate-limit errors.

--- a/content/docs/apps/event-tracking.mdx
+++ b/content/docs/apps/event-tracking.mdx
@@ -6,7 +6,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 Apps can install an [Event Tracker](/docs/storefront/event-tracking) to add storefront ecommerce Event Tracking as part of their integration.
 
-App installed event trackers simplifies the setup flow and makes using your app easy for merchants requiring fewer manual setup steps with easy configuration through the dashboard.
+An installed event tracker simplifies the setup flow and makes the app easier for merchants to use, with fewer manual setup steps and simple dashboard configuration.
 
 
 <Callout type="warn">
@@ -38,13 +38,13 @@ When building your app, map a javascript file to be installed as an [Event Track
   ]
 ```
 
-When your app is installed, an event tracker will be automatically created with the content of the javascrpt file mapped to the `storefront_event_tracker` key from your manifest.json.
+When your app is installed, an event tracker will be automatically created with the contents of the JavaScript file mapped to the `storefront_event_tracker` key in your manifest.json.
 
 ### Access App Settings Inside Event Tracker
 
-Apps also have [Settings](/docs/apps/settings) that can be used to control the configuration of how the app works, such as enabling or disabling some funcationality, or adding an ID into for the tracking script.
+Apps also have [Settings](/docs/apps/settings) that can be used to control how the app works, such as enabling or disabling functionality or adding an ID for the tracking script.
 
-Access the settings keys in your event tracker for configuration variables in your javascript.
+Access the settings keys in your event tracker to read configuration variables in your JavaScript.
 
 ```javascript title="Example Settings Usage in Snippet"
 // access your app settings through app.settings.<settings name>
@@ -58,4 +58,3 @@ if (app.settings.custom_app_id_enabled) {
 import GoogleAnalytics from '../../_snippets/_view-google-analytics.mdx';
 
 <GoogleAnalytics />
-

--- a/content/docs/apps/guides/server-to-server-apps.mdx
+++ b/content/docs/apps/guides/server-to-server-apps.mdx
@@ -6,13 +6,13 @@ tags:
 ---
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Server to Server apps are those that leverage the [Oauth flow](/docs/apps/oauth) to obtain API Access and then use the [Admin APIs](/docs/admin-api) and [Webhooks](/docs/webhooks) to subscribe to store event activity.
+Server-to-server apps leverage the [OAuth flow](/docs/apps/oauth) to obtain API access and then use the [Admin APIs](/docs/admin-api) and [Webhooks](/docs/webhooks) to subscribe to store event activity.
 
 
 <Callout type="info">
-Server to Server apps don't need to upload any "code" or files to Next Commerce, their apps are fully external and simply use Oauth to obtain Admin API access.
+Server-to-server apps don't need to upload any code or files to Next Commerce; they are fully external and simply use OAuth to obtain Admin API access.
 </Callout>
-In this guide, we'll show you how to create your first app to get you up and running and familiar with many of the concepts.
+In this guide, we'll walk through creating your first app so you can get up and running with the core concepts.
 
 ## Preparation
 
@@ -33,18 +33,18 @@ import DevelopmentStore from '../../../_snippets/_offer-development-store.mdx';
 2. After creating your App, you'll be able to see your App details. Take note of your `Client ID` and `Client Secret` which are used in the [OAuth flow](/docs/apps/oauth) to retrieve an API Access Token during the [App Install flow](/docs/apps/oauth/getting-started).
 
 
-## Configure App Oauth
+## Configure App OAuth
 
-Server-to-Server apps use follow the [OAuth flow](/docs/apps/oauth) to get and Admin API Access Token, let's add the [Oauth 2.0 <debugger/>](https://oauthdebugger.com/) urls to our app to simulate the install flow.
+Server-to-server apps use the [OAuth flow](/docs/apps/oauth) to get an Admin API access token. Let's add the [OAuth 2.0 <debugger/>](https://oauthdebugger.com/) URLs to our app to simulate the install flow.
 
-1. In **App > Settings** add `https://oauthdebugger.com/debug` as your App URL and Redirect URL to configure you app to use oauth debugger.
+1. In **App > Settings**, add `https://oauthdebugger.com/debug` as your App URL and Redirect URL to configure your app to use OAuth Debugger.
 
 2. Install your app on your store using the **Install Link** tool on your App Overview.
 
 
 ## Test App On Development Store
 
-1. You can now use [Oauth Debugger](https://oauthdebugger.com/) to simulate the Oauth flow.
+1. You can now use [OAuth Debugger](https://oauthdebugger.com/) to simulate the OAuth flow.
 
 
-Your app should now be installed and ready to testing and further development to build the Oauth. :raised_hands:
+Your app should now be installed and ready for testing and further development. :raised_hands:

--- a/content/docs/apps/index.mdx
+++ b/content/docs/apps/index.mdx
@@ -6,9 +6,9 @@ import { Callout } from 'fumadocs-ui/components/callout';
 import { Cards, Card } from 'fumadocs-ui/components/card';
 
 <Callout type="info">
-Apps and supporting tools are in Public Beta, if you have questions or run into any issues, don't hesitate to reach out to support@29next.com. More documentation, more examples, and more tools are on the way.
+Apps and supporting tools are in Public Beta. If you have questions or run into any issues, don't hesitate to reach out to support@29next.com. More documentation, examples, and tools are on the way.
 </Callout>
-Apps allow you to extend built-in functionality of the Next Commerce platform to solve merchant challenges and create new functionality all wrapped into an easily installed App.
+Apps let you extend built-in functionality of the Next Commerce platform to solve merchant challenges and ship new functionality as an easily installed app.
 
 ### Apps Allow You To
 
@@ -17,17 +17,17 @@ Apps allow you to extend built-in functionality of the Next Commerce platform to
 Use [Webhooks](/docs/webhooks) to subscribe to events and the [Admin API](/docs/admin-api) to add new logic and integrations, see the [Server to Server Guide](/docs/apps/guides/server-to-server-apps).
 
 #### Extend Storefront Themes
-Use [Event Tracking](/docs/apps/event-tracking) or [App Snippets](#app-snippets) to extend storefront themes, see the [Storefront Extension Guide](/docs/apps/guides/storefront-extension).
+Use [Event Tracking](/docs/apps/event-tracking) or [App Snippets](https://developers.nextcommerce.com/docs/apps/snippets) to extend storefront themes, see the [Storefront Extension Guide](/docs/apps/guides/storefront-extension).
 
 ### Example Apps
 
-We have full featured open source example apps that provide full code examples for many of the concepts required for building apps.
+We have full-featured, open-source example apps that provide complete code examples for many of the concepts needed to build apps.
 
 | Example Apps | Description | Link |
 | ------ | ------ | ----- |
-| Example S2S App | Server to Server demonstration of [OAuth Flow](/docs/apps/oauth), [Session Tokens](/docs/apps/oauth/session-auth), [Remote Settings](/docs/apps/settings), [Webhook Setup](/docs/webhooks) and [Verification](/docs/webhooks#verifying-webhook-requests) | [View](https://github.com/NextCommerceCo/example-app) |
-| Google Analytics 4 | Demonstrates [Snippets](/docs/apps/snippets) and [Event Tracking](/docs/apps/event-tracking) to add javascript events to storefronts. | [View](https://github.com/NextCommerceCo/google-analytics-4) |
-| Fulfillment Service App | Demonstrates demonstration of [OAuth Flow](/docs/apps/oauth) and the [Fulfillment Flow](/docs/apps/guides/fulfillment-service#fulfillment-flow-detail) using the [Fulfillment APIs](/docs/admin-api/reference/fulfillment/fulfillmentOrdersList). | [View](https://github.com/NextCommerceCo/demo-fulfillment-service-app) |
+| Example S2S App | Server-to-server example covering [OAuth flow](/docs/apps/oauth), [session tokens](/docs/apps/oauth/session-auth), [remote settings](/docs/apps/settings), [webhook setup](/docs/webhooks), and [verification](/docs/webhooks#verifying-webhook-requests). | [View](https://github.com/NextCommerceCo/example-app) |
+| Google Analytics 4 | Demonstrates [snippets](/docs/apps/snippets) and [event tracking](/docs/apps/event-tracking) for storefront integrations. | [View](https://github.com/NextCommerceCo/google-analytics-4) |
+| Fulfillment Service App | Demonstrates the [OAuth flow](/docs/apps/oauth) and the [fulfillment flow](/docs/apps/guides/fulfillment-service#fulfillment-flow-detail) using the [Fulfillment APIs](/docs/admin-api/reference/fulfillment/fulfillmentOrdersList). | [View](https://github.com/NextCommerceCo/demo-fulfillment-service-app) |
 
 
 

--- a/content/docs/storefront/graphql/index.mdx
+++ b/content/docs/storefront/graphql/index.mdx
@@ -8,7 +8,7 @@ Build custom sidecarts, upsell flows, and dynamic storefront experiences with th
 
 ## API Endpoint
 
-```bash title="Storefront GrapQL Endpoint"
+```bash title="Storefront GraphQL Endpoint"
 https://{store}.29next.store/api/graphql/
 ```
 
@@ -34,7 +34,7 @@ GraphiQL lets you:
 - **Test in real-time** — run queries and mutations against your store and see the JSON response instantly
 - **Validate syntax** — get inline error highlighting and autocomplete as you type
 
-```bash title="Storefront GrapQL Endpoint"
+```bash title="Storefront GraphQL Endpoint"
 https://{store}.29next.store/api/graphql/
 ```
 

--- a/content/docs/storefront/index.md
+++ b/content/docs/storefront/index.md
@@ -2,13 +2,13 @@
 title: Storefront
 ---
 
-The Next Commerce storefront is a flexible, customizable front-end layer for your ecommerce business. Whether you're building a completely custom storefront or enhancing an existing theme, this section will guide you through the tools and features available for developers.
+The Next Commerce storefront is a flexible, customizable front-end layer for your ecommerce business. Whether you're building a completely custom storefront or enhancing an existing theme, this section will guide you through the tools and features available to developers.
 
 ### Themes
 
 Themes allow you to fully control the look and feel of your storefront using modern front-end technologies. Each theme includes layouts, templates, stylesheets, and scripts, giving you full creative freedom to build a branded customer experience.
 
-- Customize homepage, products, catalogue and pages
+- Customize homepage, products, catalog, and pages
 - Easily manage theme assets (CSS, JS, images)
 - Customize themes via the dashboard or CLI (Theme Kit)
 
@@ -21,7 +21,7 @@ Capture user behavior, conversion events, and key storefront interactions with b
 
 - Track add-to-cart, purchases, and other standard ecommerce events
 - Hook into page views, checkout events, and custom triggers
-- Integrate storefronte events with external platforms
+- Integrate storefront events with external platforms
 
 Learn how to [implement tracking for your storefront →](/docs/storefront/event-tracking)
 
@@ -31,6 +31,6 @@ Learn how to [implement tracking for your storefront →](/docs/storefront/event
 Power deeper customizations, dynamic content loading, and headless experiences using our Storefront GraphQL API.
 
 - Fetch products, cart data, and more in real-time.
-- Create custom funcationality such as cart upsells.
+- Create custom functionality such as cart upsells.
 
 Learn how to [query your storefront data →](/docs/storefront/graphql)

--- a/content/docs/webhooks/index.mdx
+++ b/content/docs/webhooks/index.mdx
@@ -10,7 +10,7 @@ Stores can send webhooks that notify your application anytime an event happens. 
 
 ### Why Webhooks
 
-Webhooks are an efficient way to sync data from from a store in near real-time so that your app is up to date with the latest data in the store and are much more efficient than traditional polling. See example below for subscribing to `order.created` events.
+Webhooks are an efficient way to sync data from a store in near real time, keeping your app up to date without the overhead of traditional polling. See the example below for subscribing to `order.created` events.
 
 ``` mermaid
 sequenceDiagram
@@ -22,7 +22,7 @@ sequenceDiagram
 
 ### Use Cases
 
-Common use cases include but not limited to:
+Common use cases include, but are not limited to:
 
 - Integrating with external marketing platforms
 - Collecting data for external reporting applications
@@ -32,12 +32,12 @@ Common use cases include but not limited to:
 
 ### Setting Up Webhooks
 
-You can register new Webhooks through **Settings > Webhooks** or on the Admin API to send event data to your application endpoint. For each webhook, you can subscribe to All Events or select specific events to send to your endpoint. See a list of all events and example event data below.
+You can register new webhooks through **Settings > Webhooks** or the Admin API to send event data to your application endpoint. For each webhook, you can subscribe to all events or select specific events to send to your endpoint. See a list of all events and example event data below.
 
 <Callout type="warn">
-Webhook target endpoints must accept JSON data and respond with a `200` response code. If we do not receive a `200` response, we will retry up to 10 times over a several day period on an exponential back off schedule.
+Webhook target endpoints must accept JSON data and respond with a `200` response code. If we do not receive a `200` response, we will retry up to 10 times over a several-day period on an exponential backoff schedule.
 
-**Failing webhooks will trigger email notifications to all store admins and will be eventually deactivated.**
+**Failing webhooks will trigger email notifications to all store admins and will eventually be deactivated.**
 
 Returning a `410` response code indicates the target resource is no longer available and will automatically disable the webhook.
 </Callout>
@@ -70,7 +70,7 @@ Returning a `410` response code indicates the target resource is no longer avail
 
 ### Webhook Data Structure
 
-Webhook data structure follows our Admin API data structures (serializers) making them predictable. As a general rule of thumb, data available in a webhook payload data is the same as retrieving the specific data. You can setup test webhooks and view the webhook logs in the dashboard to assist in building your webhook receiver.
+Webhook payloads follow the same structure as Admin API data serializers, which makes them predictable. In general, the data in a webhook payload matches the data you would get by retrieving the same resource through the API. You can set up test webhooks and view the webhook logs in the dashboard to help build and verify your receiver.
 
 ```json title="Webhook Event Payload Structure"
 {
@@ -79,7 +79,7 @@ Webhook data structure follows our Admin API data structures (serializers) makin
     "event_id": "<unique event id>",
     "event_type": "<event type>",
     "webhook": "<webhook info>",
-    "api_version": "<webhook api version"
+    "api_version": "<webhook api version>"
 }
 
 ```

--- a/content/docs/webhooks/index.mdx
+++ b/content/docs/webhooks/index.mdx
@@ -79,7 +79,7 @@ Webhook payloads follow the same structure as Admin API data serializers, which 
     "event_id": "<unique event id>",
     "event_type": "<event type>",
     "webhook": "<webhook info>",
-    "api_version": "<webhook api version>"
+    "api_version": "2023-02-10"
 }
 
 ```


### PR DESCRIPTION
This PR cleans up docs copy and linking across the top-level docs and shared app snippets.

Highlights:
- Fixes App Snippets and development-store links in the Apps docs
- Improves grammar, voicing, and spelling on the main landing pages
- Cleans up the shared app usage snippet and app onboarding text
- Renames the GraphQL endpoint label typo

Note: some API/reference links still appear broken in source-level link validation because those pages are generated during the build step.