### PR TITLE
Document bulk subscription pause actions

### DIFF
--- a/content/docs/admin-api/guides/subscription-management.mdx
+++ b/content/docs/admin-api/guides/subscription-management.mdx
@@ -229,13 +229,25 @@ To cancel a subscription, use the [subscriptionsCancelCreate](/docs/admin-api/re
 }
 ```
 
-### Bulk Subscription Updates
+### Bulk Subscription Actions
 
 <Callout type="idea">
-The [`/next-bulk-subscription`](https://github.com/NextCommerceCo/skills/tree/main/next-bulk-subscription) skill in the Next Commerce AI skills repo wraps this workflow — CSV ingestion, dry-run validation, rate limiting, and results reporting — for Claude Code, Cursor, and other AI coding agents.
+The [`/next-bulk-subscription`](https://github.com/NextCommerceCo/skills/tree/main/next-bulk-subscription) skill in the Next Commerce AI skills repo wraps this workflow — CSV ingestion, dry-run validation, rate limiting, and results reporting for bulk pauses, cancellations, renewal-date shifts, and other subscription updates — for Claude Code, Cursor, and other AI coding agents.
 </Callout>
 
-For operations that affect a cohort of subscriptions — shifting renewal dates, cancelling a churn-risk segment, or migrating subscriptions between payment gateways — iterate the [subscriptionsPartialUpdate](/docs/admin-api/reference/subscriptions/subscriptionsPartialUpdate) endpoint over your list of subscription IDs. Respect the **4 requests/second rate limit** (sleep ~0.26s between calls) and write the result of each PATCH to a log file so failures can be retried without re-running the whole batch.
+For operations that affect a cohort of subscriptions, iterate the endpoint that matches the subscription action: use [subscriptionsPauseCreate](/docs/admin-api/reference/subscriptions/subscriptionsPauseCreate) for pauses, [subscriptionsCancelCreate](/docs/admin-api/reference/subscriptions/subscriptionsCancelCreate) for cancellations, and [subscriptionsPartialUpdate](/docs/admin-api/reference/subscriptions/subscriptionsPartialUpdate) for field updates such as renewal dates, cadence, addresses, or payment gateway details. Respect the **4 requests/second rate limit** (sleep ~0.26s between calls) and write each response to a log file so failures can be retried without re-running the whole batch.
+
+**Bulk pause.** Loop [subscriptionsPauseCreate](/docs/admin-api/reference/subscriptions/subscriptionsPauseCreate) across the list, passing the same `pause_until` date for the cohort, a per-row `pause_until` from your input file, or `{}` for indefinite pauses.
+
+```json title="Pause Subscription" http-method="POST" http-target="https://{store}.29next.store/api/admin/subscriptions/{id}/pause/"
+{
+    "pause_until": "2026-08-01"
+}
+```
+
+<Callout type="warn">
+Do not bulk pause by PATCHing `status: "paused"`. Use the pause endpoint so the platform records the pause lifecycle fields and applies pause behavior consistently.
+</Callout>
 
 **Bulk renewal-date shift.** Update each subscription's `next_renewal_date` to defer or align upcoming charges across a cohort.
 


### PR DESCRIPTION
Summary: Updates the subscription management guide to describe bulk pause via subscriptionsPauseCreate, cancellation via subscriptionsCancelCreate, and partial updates for field edits. Validation: git diff --check; npm run build.