### PR TITLE
Align campaigns docs with Page Kit template shape

### DIFF
--- a/content/docs/campaigns/page-kit.mdx
+++ b/content/docs/campaigns/page-kit.mdx
@@ -332,10 +332,12 @@ Then add an entry keyed by slug:
   "my-campaign": {
     "name": "My Campaign",
     "description": "My first campaign",
-    "sdk_version": "0.3.10"
+    "sdk_version": "0.4.18"
   }
 }
 ```
+
+When in doubt, copy the current `sdk_version` from the starter template registry you are matching.
 
 …and create the matching directory tree under `src/`:
 

--- a/content/docs/campaigns/templates.mdx
+++ b/content/docs/campaigns/templates.mdx
@@ -48,6 +48,12 @@ These are the options you'll see at the `campaign-init` template picker. Each on
         <span>·</span>
         <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-single-step/upsell-mv/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Upsell — MV</a>
         <span>·</span>
+        <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-single-step/upsell-bundle-stepper/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Upsell — stepper</a>
+        <span>·</span>
+        <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-single-step/upsell-bundle-tier-pills/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">pills</a>
+        <span>·</span>
+        <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-single-step/upsell-bundle-tier-cards/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">cards</a>
+        <span>·</span>
         <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-single-step/receipt/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Receipt</a>
       </div>
     </div>
@@ -70,6 +76,12 @@ These are the options you'll see at the `campaign-init` template picker. Each on
         <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-two-step/checkout/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Checkout</a>
         <span>·</span>
         <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-two-step/upsell-mv/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Upsell — MV</a>
+        <span>·</span>
+        <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-two-step/upsell-bundle-stepper/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Upsell — stepper</a>
+        <span>·</span>
+        <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-two-step/upsell-bundle-tier-pills/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">pills</a>
+        <span>·</span>
+        <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-two-step/upsell-bundle-tier-cards/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">cards</a>
         <span>·</span>
         <a href="https://nextcommerce-campaign-templates.netlify.app/olympus-mv-two-step/receipt/" target="_blank" rel="noopener" className="text-fd-foreground underline underline-offset-2 decoration-blue-500 hover:opacity-80">Receipt</a>
       </div>


### PR DESCRIPTION
## Summary
- add the MV bundle upsell pages to the campaigns template catalog
- update the scratch Page Kit example to use the current starter-template SDK version
- tell readers to copy the current SDK version from the starter template registry when unsure

## Validation
- npm run build