### PR TITLE
[codex] Document offer-based Campaigns pricing

### DIFF
--- a/components/api-page.tsx
+++ b/components/api-page.tsx
@@ -28,7 +28,7 @@ export const APIPage = createAPIPage(openapi, {
           {slots.apiPlayground}
           {slots.description}
           {slots.authSchemes}
-          {slots.paremeters}
+          {slots.parameters}
           {slots.body}
           {slots.responses}
           {slots.callbacks}
@@ -42,7 +42,7 @@ export const APIPage = createAPIPage(openapi, {
           {slots.header}
           {slots.description}
           {slots.authSchemes}
-          {slots.paremeters}
+          {slots.parameters}
           {slots.body}
           {slots.responses}
           {slots.callbacks}

--- a/content/docs/campaigns/bundle-selector/prices.mdx
+++ b/content/docs/campaigns/bundle-selector/prices.mdx
@@ -31,6 +31,10 @@ Currency formatting uses the ISO 4217 code returned by the price fetch API. Befo
 
 A `next-loading` class and `data-next-loading="true"` are set on the card element during price fetches.
 
+<Callout type="warn">
+For SDK 0.4.x campaigns, `originalPrice` is the pre-discount value returned by the price calculation. Do not rely on package-level Retail Price for new bundle-selector builds; model compare-at savings with Campaign Offers instead.
+</Callout>
+
 ---
 
 ## External Price Display

--- a/content/docs/campaigns/bundle-selector/reference/attributes.mdx
+++ b/content/docs/campaigns/bundle-selector/reference/attributes.mdx
@@ -99,6 +99,8 @@ Use `data-next-display="bundle.{selectorId}.{property}"` on any element in the d
 | `isSelected` | boolean | `true` when this bundle card is currently selected |
 | `name` | text | Value of `data-next-bundle-name` on the card element |
 
+`originalPrice` is the pre-discount value returned by the price calculation. For new SDK 0.4.x campaigns, model compare-at savings with Offers rather than package-level Retail Price.
+
 **Deprecated properties** (still supported for backwards compatibility):
 
 | Property | Use instead |

--- a/content/docs/campaigns/cart-system/reference/attributes.mdx
+++ b/content/docs/campaigns/cart-system/reference/attributes.mdx
@@ -215,8 +215,8 @@ Used inside the `<template>` of a `data-summary-lines` container. Replace `{line
 |----------|-------------|
 | `{line.price}` | Per-unit price as configured in the campaign |
 | `{line.priceTotal}` | `{line.price}` × quantity for this line |
-| `{line.priceRetail}` | Full retail (compare-at) price per unit |
-| `{line.priceRetailTotal}` | Retail price × quantity |
+| `{line.priceRetail}` | Legacy retail (compare-at) price per unit |
+| `{line.priceRetailTotal}` | Legacy retail price × quantity |
 | `{line.priceRecurring}` | Per-unit recurring billing price (subscriptions only) |
 | `{line.priceRecurringTotal}` | Recurring price × quantity (subscriptions only) |
 | `{line.isRecurring}` | `"true"` if this line bills on a recurring schedule |
@@ -238,7 +238,7 @@ Used inside the `<template>` of a `data-summary-lines` container. Replace `{line
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `{line.hasDiscount}` | `"show"` / `"hide"` | `"show"` when any promotion reduces this line's price |
-| `{line.hasSavings}` | `"show"` / `"hide"` | `"show"` when the unit price is below the retail (compare-at) price |
+| `{line.hasSavings}` | `"show"` / `"hide"` | Legacy helper: `"show"` when the unit price is below the package retail price |
 
 ```html
 <!-- Show a "Sale" badge only when a discount is applied to this line -->

--- a/content/docs/campaigns/data-attributes/display/cart-items-template.mdx
+++ b/content/docs/campaigns/data-attributes/display/cart-items-template.mdx
@@ -148,7 +148,7 @@ These resolve to `"show"` or `"hide"` — use them as CSS class values.
 
 | Variable | Shows when |
 |---|---|
-| `{item.showCompare}` | Item has savings (compare price visible) |
+| `{item.showCompare}` | Legacy compare price is visible |
 | `{item.showSavings}` | Item has savings |
 | `{item.showRecurring}` | Item is a subscription |
 | `{item.showUnitPrice}` | Multi-pack — unit price differs from package price |

--- a/content/docs/campaigns/data-attributes/display/package-display.mdx
+++ b/content/docs/campaigns/data-attributes/display/package-display.mdx
@@ -14,14 +14,14 @@ Display data for a specific package using the `package.[id].*` syntax. When the 
 <div>
   <h3 data-next-display="package.123.name">Product Name</h3>
   <span data-next-display="package.123.price">$0</span>
-  <s data-next-display="package.123.price_retail">$0</s>
+  <s data-next-display="package.123.price_retail">$0</s> <!-- legacy retail field -->
 </div>
 
 <!-- Shorthand — package ID inferred from parent -->
 <div data-next-package-id="123">
   <h3 data-next-display="package.name">Product Name</h3>
   <span data-next-display="package.price">$0</span>
-  <s data-next-display="package.price_retail">$0</s>
+  <s data-next-display="package.price_retail">$0</s> <!-- legacy retail field -->
 </div>
 ```
 
@@ -51,13 +51,15 @@ The shorthand makes product card components reusable across packages — use the
 | `package.[id].unitPrice` | Alias for `price` |
 | `package.[id].packageTotal` | Alias for `price_total` |
 
-### Retail / compare prices
+### Legacy retail / compare prices
+
+These fields read package-level Retail Price from Campaigns App. They are preserved for existing campaigns, but new SDK 0.4.x builds should prefer Offer-based before/after pricing from bundle selector, package toggle, cart summary, and upsell price calculations.
 
 | Path | Description |
 |---|---|
-| `package.[id].price_retail` | Per-unit retail price |
-| `package.[id].price_retail_total` | Total retail price |
-| `package.[id].unitRetailPrice` | Calculated unit retail |
+| `package.[id].price_retail` | Legacy per-unit retail price |
+| `package.[id].price_retail_total` | Legacy total retail price |
+| `package.[id].unitRetailPrice` | Calculated legacy unit retail |
 | `package.[id].comparePrice` | Alias for `price_retail_total` |
 | `package.[id].compareTotal` | Alias for `price_retail_total` |
 
@@ -90,9 +92,9 @@ These read from the active cart and reflect any applied coupons. They evaluate t
 
 ---
 
-## Combined Savings (Retail + Discounts)
+## Combined Savings (Legacy Retail + Discounts)
 
-Combines retail savings with cart discounts.
+Combines legacy retail savings with cart discounts.
 
 | Path | Description |
 |---|---|
@@ -109,6 +111,8 @@ Combines retail savings with cart discounts.
 | `package.[id].qty` | Units in the package |
 | `package.[id].unitsInPackage` | Alias for `qty` |
 | `package.[id].isBundle` | Boolean — is multi-pack (qty > 1) |
+
+Package-level `qty` is legacy Campaigns App data. For new builds, send the selected quantity from the page or component and use Offers to calculate quantity-tier pricing.
 
 ---
 

--- a/content/docs/campaigns/data-attributes/display/paths.mdx
+++ b/content/docs/campaigns/data-attributes/display/paths.mdx
@@ -42,7 +42,7 @@ Live values for a specific package. Use `package.[id].<property>` where `[id]` i
 | `package.[id].image` | Image URL |
 | `package.[id].price` | Per-unit price |
 | `package.[id].price_total` | Total package price |
-| `package.[id].price_retail` | Retail (compare-at) per-unit price |
+| `package.[id].price_retail` | Legacy retail (compare-at) per-unit price |
 | `package.[id].savingsAmount` | Total savings |
 | `package.[id].savingsPercentage` | Savings as percentage |
 | `package.[id].hasSavings` | Boolean — has savings |
@@ -55,6 +55,8 @@ Live values for a specific package. Use `package.[id].<property>` where `[id]` i
 For shorthand syntax inside a parent with `data-next-package-id`, see [Package Display](./package-display).
 
 For the full property list (including discount-context properties that require an active cart), see [Reference → Attributes](./reference/attributes).
+
+Package-level retail and quantity values are legacy Campaigns App fields. New SDK 0.4.x campaign pricing should use Offers and component-level price calculation fields such as bundle/toggle `originalPrice`, `price`, and `discountAmount`.
 
 ---
 

--- a/content/docs/campaigns/guides/bundle-set-sale.md
+++ b/content/docs/campaigns/guides/bundle-set-sale.md
@@ -24,24 +24,24 @@ The simplest setup is writing cards directly in HTML. Give each card a unique `d
        data-next-bundle-items='[{"packageId": 10, "quantity": 1}]'
        data-next-selected="true">
     <h3>Buy 1</h3>
-    <p><span data-next-bundle-price></span></p>
+    <p><span data-next-bundle-display="price"></span></p>
   </div>
 
   <div data-next-bundle-card
        data-next-bundle-id="buy2"
        data-next-bundle-items='[{"packageId": 10, "quantity": 2}]'>
     <h3>Buy 2</h3>
-    <p><span data-next-bundle-price></span></p>
-    <p>Save <span data-next-bundle-price="savings"></span></p>
+    <p><span data-next-bundle-display="price"></span></p>
+    <p>Save <span data-next-bundle-display="discountAmount"></span></p>
   </div>
 
   <div data-next-bundle-card
        data-next-bundle-id="buy3"
        data-next-bundle-items='[{"packageId": 10, "quantity": 3}]'>
     <h3>Buy 3</h3>
-    <p><span data-next-bundle-price></span></p>
-    <p>Save <span data-next-bundle-price="savings"></span></p>
-    <del><span data-next-bundle-price="compare"></span></del>
+    <p><span data-next-bundle-display="price"></span></p>
+    <p>Save <span data-next-bundle-display="discountAmount"></span></p>
+    <del><span data-next-bundle-display="originalPrice"></span></del>
   </div>
 
 </div>
@@ -69,7 +69,7 @@ The enhancer adds CSS classes you can target:
 }
 
 /* Price is loading */
-.next-bundle-card.next-loading [data-next-bundle-price] {
+.next-bundle-card.next-loading [data-next-bundle-display] {
   opacity: 0.4;
 }
 ```
@@ -117,9 +117,9 @@ When you have more than 2–3 options or want to keep HTML lean, define bundles 
     <span class="badge">{bundle.badge}</span>
     <h3>{bundle.label}</h3>
     <p class="sublabel">{bundle.sublabel}</p>
-    <p class="price"><span data-next-bundle-price></span></p>
-    <p class="savings">Save <span data-next-bundle-price="savings"></span></p>
-    <del><span data-next-bundle-price="compare"></span></del>
+    <p class="price"><span data-next-bundle-display="price"></span></p>
+    <p class="savings">Save <span data-next-bundle-display="discountAmount"></span></p>
+    <del><span data-next-bundle-display="originalPrice"></span></del>
   </div>
 </template>
 ```
@@ -139,7 +139,7 @@ A bundle can include more than one product. List each package in the `items` arr
        data-next-bundle-items='[{"packageId": 10, "quantity": 1}]'
        data-next-selected="true">
     Just the Main Product
-    <span data-next-bundle-price></span>
+    <span data-next-bundle-display="price"></span>
   </div>
 
   <!-- Main product + free gift (hidden from slot list) -->
@@ -150,7 +150,7 @@ A bundle can include more than one product. List each package in the `items` arr
          {"packageId": 99, "quantity": 1, "noSlot": true}
        ]'>
     Main Product + Free Gift
-    <span data-next-bundle-price></span>
+    <span data-next-bundle-display="price"></span>
   </div>
 
 </div>
@@ -172,7 +172,7 @@ When your products have variants (color, size), add a slot template so visitors 
        data-next-selected="true">
     <h3>Buy 2 — Pick Your Colors</h3>
     <div data-next-bundle-slots></div>
-    <p>Total: <span data-next-bundle-price></span></p>
+    <p>Total: <span data-next-bundle-display="price"></span></p>
   </div>
 
 </div>
@@ -224,10 +224,10 @@ When your products have variants (color, size), add a slot template so visitors 
     <span class="badge">{bundle.badge}</span>
     <h3>{bundle.label}</h3>
     <div class="pricing">
-      <span data-next-bundle-price></span>
-      <del data-next-bundle-price="compare"></del>
+      <span data-next-bundle-display="price"></span>
+      <del data-next-bundle-display="originalPrice"></del>
     </div>
-    <p class="savings">You save <span data-next-bundle-price="savings"></span></p>
+    <p class="savings">You save <span data-next-bundle-display="discountAmount"></span></p>
   </div>
 </template>
 

--- a/content/docs/campaigns/guides/package-selector-with-button.md
+++ b/content/docs/campaigns/guides/package-selector-with-button.md
@@ -2,11 +2,15 @@
 title: Package Selector with Add-to-Cart Button
 ---
 
-The most common product page pattern: the visitor picks an option (1 bottle, 3 bottles, 6 bottles) from a set of cards, then clicks a single "Add to Cart" button. The Package Selector tracks the choice; the button writes to the cart.
+Legacy product page pattern: the visitor picks an option from a set of package cards, then clicks a single "Add to Cart" button. The Package Selector tracks the choice; the button writes to the cart.
+
+:::caution
+For new SDK 0.4.x quantity-tier builds, prefer the [Bundle Selector](/docs/campaigns/bundle-selector) with one product/variant package and Offer-based tier pricing. Use this package-selector pattern only when an existing campaign intentionally models each option as a separate package record.
+:::
 
 ## What You're Building
 
-- A row of selectable package cards (e.g. buy 1 / buy 3 / buy 6)
+- A row of selectable package cards from an existing package-per-option campaign
 - Each card shows the price and optional savings pulled from the backend
 - One card is pre-selected by default
 - A single "Add to Cart" button that reads the current selection and adds it

--- a/content/docs/campaigns/guides/selling-addons.md
+++ b/content/docs/campaigns/guides/selling-addons.md
@@ -9,7 +9,7 @@ Add-ons are optional extras — warranties, insurance, accessories, or upgrades 
 An add-on section where:
 - Each add-on is a clickable card that adds or removes the package from the cart
 - Active cards get a visual "selected" state
-- Prices are shown with optional compare-at and savings
+- Prices are shown with optional Offer-based savings
 - One add-on can optionally be pre-selected (auto-added on page load)
 - A warranty add-on can auto-match the quantity of the main product
 
@@ -23,7 +23,7 @@ An add-on section where:
        data-add-text="Add Warranty"
        data-remove-text="✓ Warranty Added">
     <h3>2-Year Warranty</h3>
-    <span data-next-toggle-price></span>
+    <span data-next-toggle-display="price"></span>
   </div>
 
   <div data-next-toggle-card
@@ -31,8 +31,8 @@ An add-on section where:
        data-add-text="Add Insurance"
        data-remove-text="✓ Insurance Added">
     <h3>Shipping Insurance</h3>
-    <span data-next-toggle-price></span>
-    <del data-next-toggle-price="compare"></del>
+    <span data-next-toggle-display="price"></span>
+    <del data-next-toggle-display="originalPrice"></del>
   </div>
 
 </div>
@@ -79,7 +79,7 @@ The enhancer applies CSS classes you can target:
 }
 
 /* Price loading */
-[data-next-toggle-card].next-loading [data-next-toggle-price] {
+[data-next-toggle-card].next-loading [data-next-toggle-display] {
   opacity: 0.4;
 }
 ```
@@ -92,7 +92,7 @@ Add `data-next-toggle-image` to any `<img>` inside a card — the enhancer fills
 <div data-next-toggle-card data-next-package-id="201">
   <img data-next-toggle-image alt="Warranty" />
   <h3>2-Year Warranty</h3>
-  <span data-next-toggle-price></span>
+  <span data-next-toggle-display="price"></span>
 </div>
 ```
 
@@ -116,8 +116,8 @@ When you have several add-ons or want to keep markup clean, define them as JSON 
        data-remove-text="✓ {toggle.label} Added">
     <img data-next-toggle-image alt="{toggle.label}" />
     <h3>{toggle.label}</h3>
-    <span data-next-toggle-price></span>
-    <del data-next-toggle-price="compare"></del>
+    <span data-next-toggle-display="price"></span>
+    <del data-next-toggle-display="originalPrice"></del>
   </div>
 </template>
 ```
@@ -159,7 +159,7 @@ When your add-on quantity should match the main product quantity — for example
        data-add-text="Add Warranty (matches your quantity)"
        data-remove-text="✓ Warranty Added">
     Add Warranty
-    <span data-next-toggle-price></span>
+    <span data-next-toggle-display="price"></span>
   </div>
 </div>
 ```
@@ -194,8 +194,8 @@ The toggle card's quantity is automatically set to the **sum of quantities** of 
       </div>
     </div>
     <div class="addon-price">
-      <span data-next-toggle-price></span>
-      <del data-next-toggle-price="compare"></del>
+      <span data-next-toggle-display="price"></span>
+      <del data-next-toggle-display="originalPrice"></del>
     </div>
     <button class="addon-button">
       <span data-next-button-text>Add</span>

--- a/content/docs/campaigns/index.mdx
+++ b/content/docs/campaigns/index.mdx
@@ -124,20 +124,27 @@ A **campaign** bundles everything needed for a checkout: packages, offers, shipp
 
 ### Packages
 
-A **package** is a virtual link to a product with custom quantity and pricing. Packages are what customers actually buy:
+A **package** is the campaign's sellable reference to a product or product variant. In SDK 0.4.x-compatible builds, keep packages focused on identity and base price:
 
-For bundle-based quantity discounts (e.g. "buy 3 for $21" or "buy 5 for $30"), use **offers** to discount the price at checkout rather than baking the discount into the package price. This keeps the package's list price intact and lets you show savings on the cart.
+- Create one package for the product or variant customers can buy.
+- Use the package's base list price as the anchor price.
+- Send the selected package ID and quantity from the page.
+- Use **offers** to discount the cart for quantity tiers, bundles, upsells, downsells, and exit-pop incentives.
+
+For bundle-based quantity discounts (e.g. "buy 3 for $21" or "buy 5 for $30"), use **offers** to discount the price at checkout rather than baking the discount into separate package records. This keeps the package list stable and lets the API return before/after pricing so the page can show savings consistently.
+
+Package-level Quantity and Retail Price are legacy compatibility fields in Campaigns App. They may still appear when the campaign setting **Enable Package Retail Price & Quantity** is enabled, but new builds should prefer Offer-based price mutation.
 
 Packages can also be **recurring** for subscription products. When you reference a package in HTML (`data-next-package-id="…"`), the ID comes from your campaign's package list in the Campaigns App.
 
 ### Offers
 
-**Offers** are discounts that apply when an order meets a condition. Two flavours:
+**Offers** are price mutation rules that apply when an order meets a condition. Two flavours:
 
 - **Offer** — automatic, applies when the cart matches the rule (checkout page only)
 - **Code** — voucher-based, applies when the customer enters a code. Codes stack **on top of** automatic offers, and codes are also the mechanism for applying discounts on **upsell pages** (where automatic offers don't run).
 
-The API returns adjusted before/after pricing so you can show savings.
+The API returns adjusted before/after pricing so you can show savings. In modern Campaigns App setup, this replaces package-level compare-at pricing for most campaigns.
 
 **Example — quantity-based bundle pricing:**
 

--- a/content/docs/campaigns/package-toggle/card-templates.mdx
+++ b/content/docs/campaigns/package-toggle/card-templates.mdx
@@ -105,8 +105,8 @@ Any field you include in the package list entry is available as a placeholder. F
 |-------------|---------------|
 | `{toggle.price}` | Formatted total price |
 | `{toggle.unitPrice}` | Formatted per-unit price |
-| `{toggle.originalPrice}` | Retail / compare-at total price |
-| `{toggle.originalUnitPrice}` | Retail / compare-at per-unit price |
+| `{toggle.originalPrice}` | Total before offer/voucher discounts |
+| `{toggle.originalUnitPrice}` | Per-unit price before offer/voucher discounts |
 | `{toggle.discountAmount}` | Savings amount (empty when no discount) |
 | `{toggle.discountPercentage}` | Discount percentage (e.g. `20.00%`) |
 | `{toggle.hasDiscount}` | `"true"` / `"false"` |

--- a/content/docs/campaigns/package-toggle/prices.mdx
+++ b/content/docs/campaigns/package-toggle/prices.mdx
@@ -44,8 +44,8 @@ The most common fields:
 |-------|---------------|
 | `price` | Total price for the card's quantity |
 | `unitPrice` | Per-unit price |
-| `originalPrice` | Retail / compare-at total price |
-| `originalUnitPrice` | Retail / compare-at per-unit price |
+| `originalPrice` | Total before offer/voucher discounts |
+| `originalUnitPrice` | Per-unit price before offer/voucher discounts |
 
 ### Savings
 
@@ -75,6 +75,10 @@ The most common fields:
 
 <Callout type="info">
 Fields like `hasDiscount`, `isRecurring`, and `isSelected` are yes/no flags. Instead of displaying text, they **show or hide** the element. For example, a "Save!" badge inside an element with `data-next-toggle-display="hasDiscount"` only appears when there is a discount.
+</Callout>
+
+<Callout type="warn">
+Package-level Retail Price is legacy campaign data. For SDK 0.4.x builds, prefer Offers so `originalPrice`, `price`, and savings fields come from the same price calculation response.
 </Callout>
 
 <Callout type="info">

--- a/content/docs/campaigns/package-toggle/reference/attributes.mdx
+++ b/content/docs/campaigns/package-toggle/reference/attributes.mdx
@@ -67,8 +67,8 @@ Place these on elements **inside** a card (or card template) to populate them wi
 | `sku` | Product SKU; empty if not set |
 | `price` | Formatted total price for the card's quantity |
 | `unitPrice` | Per-unit price |
-| `originalPrice` | Retail / compare-at total price |
-| `originalUnitPrice` | Retail / compare-at per-unit price |
+| `originalPrice` | Total before offer/voucher discounts |
+| `originalUnitPrice` | Per-unit price before offer/voucher discounts |
 | `discountAmount` | Savings amount; empty if no discount |
 | `discountPercentage` | Savings as a percentage; empty if no discount |
 | `isSelected` | Shows the element when the package is in the cart; hides it otherwise |
@@ -130,10 +130,10 @@ Use `data-next-display="toggle.{packageId}.{property}"` on any element to bind i
 | `sku` | text | Product SKU (empty if not set) |
 | `price` | currency | Total price for the card's quantity (unit price x quantity) |
 | `unitPrice` | currency | Per-unit price |
-| `originalPrice` | currency | Retail / compare-at total price |
-| `originalUnitPrice` | currency | Retail / compare-at per-unit price |
-| `discountAmount` | currency | Savings amount (compare minus total) |
-| `discountPercentage` | percentage | Discount as a percentage of the compare price |
+| `originalPrice` | currency | Total before offer/voucher discounts |
+| `originalUnitPrice` | currency | Per-unit price before offer/voucher discounts |
+| `discountAmount` | currency | Savings amount from the price calculation |
+| `discountPercentage` | percentage | Discount as a percentage of the pre-discount price |
 | `isSelected` | boolean | `true` when this package is in the cart |
 | `hasDiscount` | boolean | `true` when a discount is applied |
 | `isRecurring` | boolean | `true` when the package bills on a recurring schedule |


### PR DESCRIPTION
## Summary

- Updates Campaigns developer docs so Packages are positioned as sellable product/variant references and Offers own price mutation.
- Clarifies `originalPrice`, savings, compare-style displays, cart fields, and package/toggle/bundle docs around Offer-based calculation.
- Marks package-level retail/quantity display paths as legacy/compatibility surfaces where appropriate.
- Refreshes older guide examples away from deprecated display attributes.

## Validation

- `npm run build:preview` passed.
- `npm run validate-links` was not used as a gate because this repo currently reports broad pre-existing generated/relative link issues unrelated to this change.