### PR TITLE
docs(campaigns): refresh config for SDK 0.4.24 and fix inaccurate meta tags

### DIFF
--- a/content/docs/campaigns/analytics/examples/custom-analytics-triggers.mdx
+++ b/content/docs/campaigns/analytics/examples/custom-analytics-triggers.mdx
@@ -68,7 +68,7 @@ Include this script **after** the SDK loader but **before** the SDK initializes:
   <script src="config.js"></script>
   
   {/* Campaign Loader Script */}
-  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
   
   {/* Custom Analytics Triggers (include after loader) */}
   <script src="custom-analytics-triggers.js"></script>

--- a/content/docs/campaigns/analytics/examples/direct-ga4.mdx
+++ b/content/docs/campaigns/analytics/examples/direct-ga4.mdx
@@ -48,7 +48,7 @@ If you're using Google Tag Manager, you don't need this script - the SDK already
 
    ```html
    {/* Campaign Cart SDK */}
-   <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+   <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
 
    {/* NextDataLayer GA4 Bridge */}
    <script src="/path/to/NextDataLayer_GA4.js"></script>

--- a/content/docs/campaigns/analytics/examples/event-transformers.md
+++ b/content/docs/campaigns/analytics/examples/event-transformers.md
@@ -413,7 +413,7 @@ const processEvent = (event) => {
 
    ```html
    <!-- Campaign Cart SDK -->
-   <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+   <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
 
    <!-- Your Transformer -->
    <script src="/path/to/transformer-tiktok.js"></script>
@@ -428,7 +428,7 @@ const processEvent = (event) => {
    <script src="https://analytics.tiktok.com/i18n/pixel/sdk.js?sdkid=YOUR_PIXEL_ID"></script>
 
    <!-- Campaign Cart SDK -->
-   <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+   <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
 
    <!-- TikTok Transformer -->
    <script src="/path/to/transformer-tiktok.js"></script>

--- a/content/docs/campaigns/configuration.mdx
+++ b/content/docs/campaigns/configuration.mdx
@@ -15,7 +15,7 @@ Add the Campaign Cart SDK loader script to every page of your campaign, ideally 
 
 ```html
 <!-- Campaign Cart SDK -->
-<script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.20/dist/loader.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
 ```
 
 
@@ -44,29 +44,32 @@ window.nextConfig = {
   // Currency behavior when country changes
   currencyBehavior: 'auto', // 'auto' | 'manual'
 
+  // Required for purchase deduplication with the NEXT Storefront Meta App
+  storeName: 'store-name',
+
   // Payment and checkout configuration
   paymentConfig: {
     expressCheckout: {
-      enabled: true,
-      requireValidation: false, // Require form validation before express checkout
-      requiredFields: ['email', 'fname', 'lname'],
-      methodOrder: ['paypal', 'apple_pay', 'google_pay']
+      enabled: true, // Enable/disable express checkout methods
+      requireValidation: true, // Require form validation before express checkout (radio option only, not express buttons)
+      requiredFields: ['email', 'fname', 'lname'], // Fields required for express checkout radio option
+      methodOrder: ['paypal', 'apple_pay', 'google_pay'] // Display order of express payment method buttons
     }
   },
 
   // Address and country configuration
   addressConfig: {
-    defaultCountry: "US",
-    showCountries: ["US", "CA", "GB", "AU", "DE", "FR"],
-    dontShowStates: ["AS", "GU", "PR", "VI"],
-    enableAutocomplete: true, // NEXT Address Autocomplete
+    // defaultCountry: "US",              // Low-priority fallback, used only when the campaign country list is empty
+    // showCountries: ["US", "CA", "GB"], // Deprecated — the campaign API provides countries; fallback only
+    dontShowStates: ["AS", "GU", "PR", "VI"], // State codes to hide from dropdowns
+    enableAutocomplete: true, // Use NEXT address autocomplete (leave googleMaps.apiKey empty)
   },
 
   // Google Maps integration (address autocomplete)
+  // Leave apiKey empty to use NEXT autocomplete. Set a key to use Google Maps instead — it takes priority when non-empty.
   googleMaps: {
-    apiKey: "your-google-maps-api-key",
+    apiKey: "",
     region: "US",
-    enableAutocomplete: false 
   },
 
   // Analytics providers
@@ -74,6 +77,7 @@ window.nextConfig = {
     enabled: true,
     mode: 'auto', // 'auto' | 'manual' | 'disabled'
     providers: {
+      // NEXT Campaign analytics (always enabled when analytics.enabled is true)
       nextCampaign: {
         enabled: true
       },
@@ -83,16 +87,19 @@ window.nextConfig = {
           containerId: "GTM-XXXXXX",
           dataLayerName: "dataLayer"
         },
+        // Optional: blockedEvents: ["PageView"]
       },
       facebook: {
         enabled: false,
         settings: {
           pixelId: "YOUR_PIXEL_ID"
         },
+        // Optional: blockedEvents: ["PageView"]
       },
       rudderstack: {
         enabled: false,
-        settings: {},
+        settings: {}, // RudderStack config is handled by its own SDK; this just enables the adapter
+        // Optional: blockedEvents: ["PageView"]
       },
       custom: {
         enabled: false,
@@ -107,45 +114,17 @@ window.nextConfig = {
   // UTM parameter transfer (preserve tracking params across pages)
   utmTransfer: {
     enabled: true,
-    applyToExternalLinks: false,
-    debug: false,
-    // Optional: excludedDomains: ['example.com'],
-    // Optional: paramsToCopy: ['utm_source', 'utm_medium', 'utm_campaign', 'gclid', 'fbclid']
+    applyToExternalLinks: false, // Add UTM params to external links
+    debug: false, // Enable debug logging for UTM transfer
+    // Optional: excludedDomains: ['example.com', 'test.org'],
+    // Optional: paramsToCopy: ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'fbclid']
   }
 };
 ```
 
-## Currency Persistence
-
-Once a shopper sees a price in a specific currency, the SDK locks that currency into `sessionStorage` for the rest of the session. The cart, upsells, and order confirmation all stay in the same currency, even if geo-detection would otherwise return a different result on a later page.
-
-### How the currency is chosen on first page load
-
-| Source | Priority |
-|---|---|
-| `?currency=<code>` URL parameter | 1 — highest |
-| Previously stored session currency | 2 |
-| Result of geo-detection (when `currencyBehavior: 'auto'`) | 3 |
-| Campaign default currency | 4 — fallback |
-
-Once chosen, the value is written to `sessionStorage` and reused on every subsequent page load in the session. To reset, close the browser tab or clear sessionStorage.
-
-### `currencyBehavior`
-
-| Value | Behavior |
-|---|---|
-| `'auto'` *(default)* | Geo-detect on first load if no URL parameter or stored currency is present, then lock for the session |
-| `'manual'` | Never auto-detect. Falls back to the campaign default unless `?currency=` or a stored value is set |
-
-### Using `?currency=` to force a currency
-
-```
-https://example.com/checkout?currency=EUR
-```
-
-Useful for currency-specific ad campaigns and affiliate links. The first page to apply it locks the session — subsequent navigations within the session keep `EUR` even without the parameter.
-
----
+<Callout type="info">
+`storeName` is required for purchase deduplication when using the NEXT Storefront Meta App. Set it to your store identifier.
+</Callout>
 
 ## Meta Tag Configuration
 
@@ -164,10 +143,35 @@ Configure the SDK on a per-page basis using meta tags in your HTML `<head>`:
 <!-- Next URL: Redirect after order completion (checkout pages) -->
 <meta name="next-success-url" content="/upsell">
 
-<!-- Prevent Back Navigation: Usually on first upsell page -->
-<meta name="next-prevent-back-navigation" content="true">
-
 <!-- Upsell URLs: For upsell pages -->
 <meta name="next-upsell-accept-url" content="/receipt">
 <meta name="next-upsell-decline-url" content="/receipt">
 ```
+
+<Callout type="info">
+The upsell meta tags (`next-page-type`, `next-upsell-accept-url`, `next-upsell-decline-url`) are covered in depth on the [Upsell Flow](/docs/campaigns/upsells/flow) page. For the separate analytics meta tag family (`next-analytics-*`), see [Analytics Meta Tags](/docs/campaigns/analytics/meta-tags).
+</Callout>
+
+---
+
+## Currency Behavior
+
+The `currencyBehavior` setting controls whether the SDK geo-detects the shopper's currency. Once a shopper sees a price in a specific currency, the SDK locks that currency into `sessionStorage` for the rest of the session, so the cart, upsells, and order confirmation all stay consistent even if geo-detection would return a different result on a later page.
+
+| Value | Behavior |
+|---|---|
+| `'auto'` *(default)* | Geo-detect on first load if no URL parameter or stored currency is present, then lock for the session |
+| `'manual'` | Never auto-detect. Falls back to the campaign default unless `?currency=` or a stored value is set |
+
+### How the currency is chosen on first page load
+
+| Source | Priority |
+|---|---|
+| `?currency=<code>` URL parameter | 1 — highest |
+| Previously stored session currency | 2 |
+| Result of geo-detection (when `currencyBehavior: 'auto'`) | 3 |
+| Campaign default currency | 4 — fallback |
+
+Once chosen, the value is written to `sessionStorage` and reused on every subsequent page load in the session. To reset, close the browser tab or clear sessionStorage.
+
+To force a specific currency from a link (e.g. for currency-specific ad campaigns), use the [`?currency=` URL parameter](/docs/campaigns/data-attributes/url-parameters/reference/attributes).

--- a/content/docs/campaigns/data-attributes/order-data/get-started.mdx
+++ b/content/docs/campaigns/data-attributes/order-data/get-started.mdx
@@ -19,7 +19,7 @@ Two prerequisites:
 ```html
 <head>
   <meta name="next-page-type" content="receipt">
-  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
 </head>
 ```
 

--- a/content/docs/campaigns/guides/advanced-customization.md
+++ b/content/docs/campaigns/guides/advanced-customization.md
@@ -17,7 +17,7 @@ Build custom bundles with real-time pricing updates:
   
   <!-- SDK Configuration -->
   <meta name="next-api-key" content="your-api-key-here">
-  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
   
   <style>
     .bundle-builder {

--- a/content/docs/campaigns/upsells/flow.mdx
+++ b/content/docs/campaigns/upsells/flow.mdx
@@ -24,10 +24,7 @@ Every upsell page needs four pieces:
   <meta name="next-upsell-accept-url" content="/upsell-2">
   <meta name="next-upsell-decline-url" content="/upsell-2">
 
-  <!-- optional: prevent the customer from going back to checkout -->
-  <meta name="next-prevent-back-navigation" content="true">
-
-  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.3.10/dist/loader.js" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/gh/NextCommerceCo/campaign-cart@v0.4.24/dist/loader.js" type="module"></script>
 </head>
 <body>
   <!-- Offer markup here -->
@@ -79,22 +76,6 @@ If a page has more than one offer with different next steps, override on the but
   Basic track
 </button>
 ```
-
----
-
-## Prevent Back Navigation
-
-To stop the customer from using the browser Back button to return to checkout (which would let them re-pay or change the order), add this to the **first** upsell page:
-
-```html
-<meta name="next-prevent-back-navigation" content="true">
-```
-
-The SDK pushes a guard state into history on load. If the customer presses Back, the browser navigates forward again, keeping them on the current page.
-
-<Callout type="warn">
-Use this only on the first upsell page. Adding it to every page traps the customer in the funnel and gives them no way out.
-</Callout>
 
 ---
 

--- a/content/docs/campaigns/upsells/reference/attributes.mdx
+++ b/content/docs/campaigns/upsells/reference/attributes.mdx
@@ -112,7 +112,6 @@ Set in the page `<head>`. Read by both upsell enhancers.
 | `<meta name="next-page-type" content="upsell">` | Marks the page as an upsell page. Triggers page-view tracking and the duplicate-dialog logic |
 | `<meta name="next-upsell-accept-url" content="/path">` | Default URL to navigate to after a successful accept. Overridden by `data-next-url` on individual buttons |
 | `<meta name="next-upsell-decline-url" content="/path">` | Default URL to navigate to after a skip or a duplicate-decline |
-| `<meta name="next-prevent-back-navigation" content="true">` | Push a history guard so the customer cannot use the browser Back button to return to checkout. Use only on the first upsell page |
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes the Campaigns Cart SDK docs against the current [starter template config](https://github.com/NextCommerceCo/campaign-cart-starter-templates/blob/main/src/olympus/assets/config.js) and the latest SDK release (**v0.4.24**), and removes a meta tag that no longer exists.

## Changes

**SDK version**
- Bump the loader script from `v0.4.20` (configuration page) and `v0.3.10` (6 older snippets) to **`v0.4.24`** — now consistent across all campaigns docs.

**`configuration.mdx` — align with the starter template**
- Add the top-level `storeName` key (required for purchase deduplication with the NEXT Storefront Meta App).
- Fix `addressConfig`: `defaultCountry`/`showCountries` shown as commented fallback, with `showCountries` noted as deprecated (the campaign API provides countries).
- Fix `googleMaps`: removed the non-existent `enableAutocomplete` key; clarified how the autocomplete provider is selected.
- Reorder the page so **Meta Tag Configuration** sits above the currency content.
- Rename "Currency Persistence" → **"Currency Behavior"**, lead with the `currencyBehavior` setting, and replace the duplicated `?currency=` block with a cross-link to the canonical URL Parameters reference.
- Add a callout linking to the meta-tag deeper dives (Upsell Flow, Analytics Meta Tags).

**Remove `next-prevent-back-navigation` (not a real feature)**
- The core SDK does nothing with this meta tag, and the campaign-kit templates do not implement it either. Removed it from `configuration.mdx`, `upsells/flow.mdx` (including the false "the SDK pushes a guard state into history" claim), and the `upsells/reference/attributes.mdx` table.

## Validation

`npm run validate-links` introduces **no new errors**. The pre-existing repo-wide `baseUrl` warnings and 3 genuine errors (e.g. the deleted `javascript-api/profiles` link) are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)