### PR TITLE
[codex] Align campaign docs with SDK 0.4 setup

### DIFF
--- a/content/docs/campaigns/analytics/examples/custom-analytics-triggers.mdx
+++ b/content/docs/campaigns/analytics/examples/custom-analytics-triggers.mdx
@@ -79,10 +79,11 @@ Include this script **after** the SDK loader but **before** the SDK initializes:
 </html>
 ```
 
-### 3. Ensure Cart Has Items
+### 3. Ensure Cart State Is Available
 
 - Add items to cart before testing
-- Cart must not be empty for events to fire
+- Let the SDK emit at least one `cart:updated` event before relying on custom analytics output
+- Use the `cart:updated` payload as the primary cart source; treat `window.next.getCartData()` as a fallback snapshot
 
 ## How It Works
 
@@ -118,6 +119,10 @@ The `dl_` prefix is Campaign Cart SDK's standard event naming convention (e.g., 
 
 `ElevarDataLayer` is a separate data layer specifically for Elevar compatibility. If you're not using Elevar, you can remove the `ElevarDataLayer` references from the script - events will still work with standard GTM via `window.dataLayer`.
 </Callout>
+
+<Callout type="warn" title="Cart data source">
+For custom analytics, prefer SDK event payloads such as `cart:updated`. Current SDK builds can return a snapshot where `getCartData().cartLines` is empty even after rendered cart controls update, so do not use that property as proof that checkout or QA cart state is empty.
+</Callout>
 ## Complete Script
 
 Here's the complete JavaScript code for the custom analytics triggers:
@@ -148,12 +153,27 @@ Here's the complete JavaScript code for the custom analytics triggers:
   // Track if events have been fired to prevent duplicates
   let hasFiredAddToCart = false;
   let hasFiredBeginCheckout = false;
+  let latestCartData = null;
+
+  function rememberCartData(data) {
+    if (data) {
+      latestCartData = data;
+    }
+  }
+
+  function getCartLines(cartData) {
+    return cartData?.cartLines || cartData?.enrichedItems || cartData?.items || [];
+  }
 
   /**
-   * Get cart data from SDK
+   * Get cart data from SDK events first, then fallback snapshots
    */
   function getCartData() {
     try {
+      if (latestCartData) {
+        return latestCartData;
+      }
+
       if (typeof window.next !== 'undefined' && window.next.getCartData) {
         return window.next.getCartData();
       }
@@ -231,13 +251,14 @@ Here's the complete JavaScript code for the custom analytics triggers:
    * Format cart items for analytics
    */
   function formatCartItems(cartData, campaignData) {
-    if (!cartData || !cartData.cartLines || cartData.cartLines.length === 0) {
+    const cartLines = getCartLines(cartData);
+    if (!cartLines.length) {
       return [];
     }
 
     const currency = campaignData?.currency || cartData.campaignData?.currency || 'USD';
     
-    return cartData.cartLines.map((item, index) => {
+    return cartLines.map((item, index) => {
       // Extract packageId from enriched item (could be in different places)
       const packageId = item.packageId || item.package_id || item.id;
       
@@ -273,9 +294,10 @@ Here's the complete JavaScript code for the custom analytics triggers:
 
     const cartData = getCartData();
     const campaignData = getCampaignData();
+    const cartLines = getCartLines(cartData);
     
-    if (!cartData || !cartData.cartLines || cartData.cartLines.length === 0) {
-      console.warn('Cannot fire add_to_cart: cart is empty');
+    if (!cartLines.length) {
+      console.warn('Cannot fire add_to_cart: no cart items in latest cart:updated payload or fallback snapshot');
       return;
     }
 
@@ -346,9 +368,10 @@ Here's the complete JavaScript code for the custom analytics triggers:
 
     const cartData = getCartData();
     const campaignData = getCampaignData();
+    const cartLines = getCartLines(cartData);
     
-    if (!cartData || !cartData.cartLines || cartData.cartLines.length === 0) {
-      console.warn('Cannot fire begin_checkout: cart is empty');
+    if (!cartLines.length) {
+      console.warn('Cannot fire begin_checkout: no cart items in latest cart:updated payload or fallback snapshot');
       return;
     }
 
@@ -471,6 +494,12 @@ Here's the complete JavaScript code for the custom analytics triggers:
   function setupTriggers() {
     console.log('Setting up custom analytics triggers');
 
+    if (typeof window.next !== 'undefined' && window.next.on) {
+      window.next.on('cart:updated', function(cartState) {
+        rememberCartData(cartState);
+      });
+    }
+
     // 1. Fire add_to_cart when checkout page loads
     if (isCheckoutPage()) {
       // Wait a bit for cart to be populated
@@ -540,7 +569,7 @@ Here's the complete JavaScript code for the custom analytics triggers:
 
 1. ✅ **Config.js Setup** - Add `blockedEvents` to both GTM and Facebook providers
 2. ✅ **Include Script in HTML** - Script included after SDK loader
-3. ✅ **Ensure Cart Has Items** - Cart must not be empty for events to fire
+3. ✅ **Ensure Cart State Is Available** - Add items through rendered controls and let `cart:updated` fire before testing
 
 ### Test `add_to_cart` Event (Checkout Page Load)
 
@@ -684,10 +713,11 @@ function testCustomTriggers() {
   // Check SDK
   console.log('SDK ready:', typeof window.next !== 'undefined');
   
-  // Check cart
+  // Check cart snapshot. For proof, inspect cart:updated payloads and rendered totals too.
   if (window.next) {
     const cart = window.next.getCartData();
-    console.log('Cart items:', cart?.cartLines?.length || 0);
+    const lines = cart?.cartLines || cart?.enrichedItems || cart?.items || [];
+    console.log('Cart items in snapshot:', lines.length);
     console.log('Cart total:', cart?.cartTotals?.total?.value || 0);
   }
   
@@ -750,7 +780,7 @@ testCustomTriggers();
 
 **Check:**
 1. ✅ Script is included after SDK loader
-2. ✅ Cart has items (not empty)
+2. ✅ Cart has items from a recent `cart:updated` event or fallback snapshot
 3. ✅ Console shows "🔧 Setting up custom analytics triggers"
 4. ✅ No JavaScript errors in console
 5. ✅ SDK is initialized (`window.next` exists)
@@ -764,7 +794,8 @@ console.log('SDK ready:', typeof window.next !== 'undefined');
 if (window.next) {
   const cart = window.next.getCartData();
   console.log('Cart data:', cart);
-  console.log('Cart has items:', cart?.cartLines?.length > 0);
+  const lines = cart?.cartLines || cart?.enrichedItems || cart?.items || [];
+  console.log('Cart has items in snapshot:', lines.length > 0);
 }
 ```
 
@@ -785,9 +816,9 @@ if (window.next) {
 ### Issue: Missing Data in Events
 
 **Check:**
-- Cart must have items before events fire
+- Cart state must include items before events fire
 - Campaign data must be loaded (for currency, package info)
-- Check console for warnings: `"Cannot fire add_to_cart: cart is empty"`
+- Check console for warnings: `"Cannot fire add_to_cart: no cart items in latest cart:updated payload or fallback snapshot"`
 
 ## Success Criteria
 
@@ -823,7 +854,6 @@ Open browser console to see these messages and verify events are firing correctl
 
 - Events are only fired once per page load (duplicate prevention)
 - Script waits for SDK to be ready before setting up listeners
-- Cart must have items for events to fire
+- Cart state must include items for events to fire
 - Script gracefully handles missing SDK or analytics tools
 - Events use the same format as SDK defaults for consistency
-

--- a/content/docs/campaigns/api/index.mdx
+++ b/content/docs/campaigns/api/index.mdx
@@ -5,9 +5,9 @@ sidebar_position: 1
 ---
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Campaigns App opens up new possibilities for frontend developers to easily create complex external campaign flows using Javascript, **no backend server-side integration required**.
+Campaigns App opens up new possibilities for frontend developers to easily create complex external campaign flows using JavaScript, **no backend server-side integration required**.
 
-The Campaigns App provides an easy to use CORS enabled API that follows the best practices for integrating to our Admin API for an [External Checkout Flow](/docs/admin-api/guides/external-checkout).
+The Campaigns App provides an easy-to-use CORS-enabled API that follows the best practices for integrating to our Admin API for an [External Checkout Flow](/docs/admin-api/guides/external-checkout).
 
 <Callout type="idea" title="Recommended: use the Campaign Cart SDK">
 For most projects, start with the **[Campaigns Getting Started guide](/docs/campaigns)** — it walks you through scaffolding a working funnel with Page Kit and the Campaign Cart SDK, which wraps every endpoint on this page behind data-attribute driven add-to-cart, live cart state, coupon handling, checkout forms, and upsell flows. You write HTML, not fetch calls. The [Cart System](/docs/campaigns/cart-system) and [JavaScript API](/docs/campaigns/javascript-api) docs cover the SDK in depth.
@@ -17,22 +17,22 @@ Use the raw API on this page only for custom server-side flows or backend integr
 
 ## Campaigns Overview
 
-A "campaign" is a defined set of packages and payment rules as a backend for the HTML/JS webpages of a campaign (or funnel) frontend. You can easily setup multiple campaigns for different product offers, markets, and A/B testing.
+A "campaign" is a defined set of packages, offers, shipping options, payment rules, and localization settings that backs the HTML/JS pages of a campaign funnel. You can set up multiple campaigns for different product offers, markets, and A/B tests.
 
 
 ### Session Tracking
 
 Session tracking is available to enable visibility into campaign performance by adding a [javascript snippet](#add-session-tracking) to the head of every page on your campaign. With session tracking configured, we'll automatically track events for:
 
-- Page Veiw
+- Page View
 - Cart Create
 - Order Create
 - Upsell Create
 
-These events flow into Campaign Performance reports for real time monitoring of acvitities on your campaign.
+These events flow into Campaign Performance reports for real-time monitoring of activity on your campaign.
 
 ### Packages
-A **package** is a virtual link to a product in your campaign — what customers reference by `package_id` when creating carts and orders. Each package points to one product with a default quantity (e.g. 1x or 3x for bundles), and can optionally be recurring (subscription).
+A **package** is a virtual link to a product or product variant in your campaign — what customers reference by `package_id` when creating carts and orders. In SDK 0.4.x-compatible builds, create packages for product or variant identity and send the selected quantity from the page. Older campaigns may still expose package-level quantity for compatibility, but new quantity tiers should be modeled with offers rather than separate `1x`, `2x`, and `3x` package records.
 
 Pricing adjustments — per-quantity bundle discounts, automatic offers, coupon codes — are controlled by **offers**, not by per-package pricing rules. The cart and order APIs return adjusted before/after totals so the frontend can render savings without doing math.
 

--- a/content/docs/campaigns/index.mdx
+++ b/content/docs/campaigns/index.mdx
@@ -6,7 +6,7 @@ import { CampaignFunnelFlow, CampaignAnatomy } from '@/components/campaign-conce
 
 Campaigns are fully custom checkout funnels — landing, checkout, upsell, and receipt pages — backed by a CORS-enabled API that handles products, pricing, payments, and order creation. **No backend integration required.**
 
-The fastest path from zero to a working funnel on localhost is the **[Campaign Page Kit](https://github.com/NextCommerceCo/campaign-page-kit)**: a CLI that scaffolds a starter template, runs a hot-reload dev server, and outputs a static site you can deploy to Netlify, Cloudflare Pages, Vercel, or any static host.
+The fastest path from zero to a working funnel on localhost is the **[Campaign Page Kit](https://github.com/NextCommerceCo/campaign-page-kit)**: a CLI that scaffolds an SDK-ready starter template, runs a hot-reload dev server, and outputs a static site you can deploy to Netlify, Cloudflare Pages, Vercel, or any static host.
 
 ## Quick Start
 
@@ -53,7 +53,7 @@ npm run dev
 This opens your campaign's first page (e.g. `/<slug>/presell/`) in the browser and hot-reloads as you edit. If you have multiple campaigns in the project, you'll get a picker.
 
 <Callout type="success" title="🎉 You did it!">
-You now have a **complete campaign funnel** running on your local machine — presell, landing, checkout, upsells, and receipt — all wired up to your live store data through the SDK. Click through it, created a test order (see test card below).
+You now have a **complete campaign funnel** running on your local machine — presell, landing, checkout, upsells, and receipt — all wired up to your live store data through the SDK. Click through it and create a test order using the test card below.
 </Callout>
 
 ### 4. Place a test order
@@ -93,7 +93,7 @@ my-campaigns/
 
 ## Starter templates
 
-Pick one at the `campaign-init` template prompt. Each template ships with `presell.html` + `landing.html`, all upsell variants, and a receipt — copy the whole folder to get the full funnel. The two Olympus templates are a good starting point for your first campaign.
+Pick one at the `campaign-init` template prompt. Each template ships with SDK-ready checkout, upsell, and receipt surfaces, plus the supporting presell and landing pages for that family. Start from a maintained template, then replace campaign-specific copy, assets, package IDs, offer codes, shipping methods, tracking, and routes with values from Campaigns App and your build brief. The two Olympus templates are a good starting point for your first campaign.
 
 <CampaignTemplatesGrid slugs={['olympus', 'olympus-mv-single-step']} />
 
@@ -129,9 +129,9 @@ A **package** is the campaign's sellable reference to a product or product varia
 - Create one package for the product or variant customers can buy.
 - Use the package's base list price as the anchor price.
 - Send the selected package ID and quantity from the page.
-- Use **offers** to discount the cart for quantity tiers, bundles, upsells, downsells, and exit-pop incentives.
+- Use **offers** to discount checkout quantity tiers and **Code** offers for upsells, downsells, and exit-pop incentives.
 
-For bundle-based quantity discounts (e.g. "buy 3 for $21" or "buy 5 for $30"), use **offers** to discount the price at checkout rather than baking the discount into separate package records. This keeps the package list stable and lets the API return before/after pricing so the page can show savings consistently.
+For bundle-based quantity discounts (e.g. "buy 3 for $21" or "buy 5 for $30"), use **offers** to discount the price at checkout rather than baking the discount into separate package records. This keeps the package list stable and lets the API return before/after pricing so template components can show savings consistently.
 
 Package-level Quantity and Retail Price are legacy compatibility fields in Campaigns App. They may still appear when the campaign setting **Enable Package Retail Price & Quantity** is enabled, but new builds should prefer Offer-based price mutation.
 

--- a/content/docs/campaigns/javascript-api/attribution-metadata.mdx
+++ b/content/docs/campaigns/javascript-api/attribution-metadata.mdx
@@ -30,7 +30,7 @@ All fields use `object: "attribution"` and `enable_export: true`.
 | `domain` | text | Domain where the conversion occurred |
 | `landing_page` | text | Page URL where the customer landed or converted |
 | `referrer` | text | Full referrer URL including tracking parameters |
-| `sdk_version` | text | Campaign Cart SDK version that processed the order (e.g., `0.3.10`) |
+| `sdk_version` | text | Campaign Cart SDK version that processed the order (e.g., `0.4.24`) |
 | `timestamp` | integer | Order submission timestamp in epoch milliseconds |
 | `user_ip` | text | Customer IP address at time of order (IPv4 or IPv6) |
 
@@ -83,7 +83,7 @@ When all fields are configured, the SDK sends attribution metadata like this wit
   "domain": "osmo-official.com",
   "landing_page": "https://osmo-official.com/us/checkout-flashlight-v2",
   "referrer": "https://osmo-official.com/us/flashlight-v4?clickid=69e039c421910a0bc1ffecc6&rtkcid=...",
-  "sdk_version": "0.3.10",
+  "sdk_version": "0.4.24",
   "timestamp": 1776302818758,
   "user_ip": "2601:441:4580:5760:b4c4:2214:9d19:2e54"
 }

--- a/content/docs/campaigns/templates.mdx
+++ b/content/docs/campaigns/templates.mdx
@@ -7,6 +7,6 @@ description: The starter templates you can install with page kit, get your campa
 
 All templates are available for download on GitHub at [NextCommerceCo/campaign-cart-starter-templates](https://github.com/NextCommerceCo/campaign-cart-starter-templates). You can browse the source or clone individual templates directly from the repository.
 
-These are the options you'll see at the `campaign-init` template picker. Each one installs a complete funnel into your project.
+These are the options you'll see at the `campaign-init` template picker. Each one installs a complete funnel into your project with SDK-ready checkout, cart, upsell, and receipt surfaces. Treat those commerce surfaces as runtime wiring: replace campaign-specific package IDs, offer codes, shipping methods, copy, assets, and routes, but avoid rebuilding the SDK-owned controls from scratch.
 
 <CampaignTemplatesGrid />

--- a/content/docs/campaigns/upsells/quantity.mdx
+++ b/content/docs/campaigns/upsells/quantity.mdx
@@ -83,7 +83,7 @@ The toggle whose value matches the current quantity gets the `next-selected` cla
 ```
 
 <Callout type="warn">
-Quantity toggle cards do **not** override the package — they only set the quantity. To offer different bundle sizes as different packages (e.g., a `pkg-1`, `pkg-3`, `pkg-5`), use [option cards](./selectors#built-in-option-cards) instead.
+Quantity toggle cards do **not** override the package — they only set the quantity. For a larger quantity of the same upsell product, keep the same package and apply any upsell discount with a Code offer. Use [option cards](./selectors#built-in-option-cards) only when the choices are genuinely different package identities, such as a different product, variant, or subscription option.
 </Callout>
 
 ---


### PR DESCRIPTION
## Summary
- align campaign concepts and Campaigns API language with the SDK 0.4 package identity + Offer pricing model
- clarify starter templates as SDK-ready runtime surfaces for checkout, cart, upsells, and receipts
- update upsell quantity guidance and attribution examples away from legacy 0.3.x assumptions
- adjust the custom analytics example to prefer cart:updated event payloads over getCartData().cartLines as proof

## Validation
- npm run build
- npm run validate-links (fails on existing repo-wide reference/relative-link issues: 76 errored files, 293 errors)