### PR TITLE
Fix stale docs.29next.com user docs links

### DIFF
--- a/content/docs/admin-api/guides/external-checkout.mdx
+++ b/content/docs/admin-api/guides/external-checkout.mdx
@@ -203,7 +203,7 @@ Users are first checked for an existing user by `email` before creating a new us
 **It is not recommended to pass `phone_number` directly on the user when creating a cart or order, we recommend passing a local phone number in the `shipping_address` instead.** Address fields have country context, which allows local phone numbers to be passed and converted to [E.164 format](https://en.wikipedia.org/wiki/E.164) before being saved. A `phone_number` passed to the `user` object directly must be in E.164 format.
 </Callout>
 ### Cart / Order Attribution Detail
-Cart and Order `attribution` object sets the [marketing attribution](https://docs.29next.com/features/marketing-attribution) on the order for tracking the source of orders and use in orders reporting. You can also pass in [metadata](https://docs.29next.com/start-here/technical-settings/metadata-fields) fields that are configured on the store to track custom attribution parameters and integrate external tracking platforms.
+Cart and Order `attribution` object sets the [marketing attribution](https://docs.nextcommerce.com/docs/features/offers/marketing-attribution) on the order for tracking the source of orders and use in orders reporting. You can also pass in [metadata](https://docs.nextcommerce.com/docs/build-a-store/technical-settings/metadata-fields-and-tags) fields that are configured on the store to track custom attribution parameters and integrate external tracking platforms.
 
 ```json title="Attribution Detail"
 "attribution": {
@@ -270,5 +270,4 @@ Descriptors can be up to 22 alphanumeric characters, spaces, and these special c
 See the [**Payment Methods**](/docs/admin-api/guides/payment-methods) section for method-specific guides on creating orders, plus the full capability matrix (flow type, express checkout, upsell, and subscription support per method).
 
 **[View all payment methods →](/docs/admin-api/guides/payment-methods)**
-
 

--- a/content/docs/apps/guides/dispute-service.mdx
+++ b/content/docs/apps/guides/dispute-service.mdx
@@ -81,7 +81,7 @@ Apple Pay, Google Pay, and other tokenized payment methods use virtualized card 
 
 ### Step 6 - Customer is added to block lists
 
-Merchants can configure their store to automatically add customers to block lists when any of their transactions have been disputed to mitigate future risk from the customer and associated payment methods. See [Block Lists](https://docs.29next.com/features/payments/block-lists) guide in our user docs.
+Merchants can configure their store to automatically add customers to block lists when any of their transactions have been disputed to mitigate future risk from the customer and associated payment methods. See [Block Lists](https://docs.nextcommerce.com/docs/features/payments/block-lists) guide in our user docs.
 
 
 ### Step 7 - Dispute service creates refund
@@ -238,6 +238,3 @@ To resolve a dispute, update the dispute with the appropriate [resolution](#disp
   "resolution": "issued_full_refund"
 }
 ```
-
-
-

--- a/content/docs/apps/guides/fulfillment-service.mdx
+++ b/content/docs/apps/guides/fulfillment-service.mdx
@@ -76,7 +76,7 @@ graph
 
 Fulfillment Services need to create `Locations` which represent their warehouses where physical products are stored and fulfilled from. Product `stockrecords` must be associated with a location for fulfillment.
 
-When new orders are created, the fulfillment orders are assigned to the locations based on [Fulfillment Routing](https://docs.29next.com/features/fulfillment-guide/location-based-routing). The Location Address is also used for Tax calculation. See the [Locations Create](/docs/admin-api/reference/fulfillment/locationsCreate) endpoint to create a location.
+When new orders are created, the fulfillment orders are assigned to the locations based on [Fulfillment Routing](https://docs.nextcommerce.com/docs/features/fulfillment-guide/location-based-routing). The Location Address is also used for Tax calculation. See the [Locations Create](/docs/admin-api/reference/fulfillment/locationsCreate) endpoint to create a location.
 
 ### Location Callback
 The location `callback` is a URL the store will send `Fulfillment Request` webhooks to notify them of a new fulfillment assigned. Fulfillment Services need to query their [Assigned Fulfillment Orders](#assigned-fulfillment-orders) to retrieve the fulfillment order details.
@@ -257,7 +257,7 @@ Once you have tracking information for your the outgoing shipment to the custome
 
 ## Sync Product Inventory
 
-Products have "stock records" which represent the available physical stock at a fulfillment location. Often a single product can be stocked at multiple locations, with [Fulfillment Routing](https://docs.29next.com/features/fulfillment-guide/location-based-routing) governing the order fulfillment location assignment.
+Products have "stock records" which represent the available physical stock at a fulfillment location. Often a single product can be stocked at multiple locations, with [Fulfillment Routing](https://docs.nextcommerce.com/docs/features/fulfillment-guide/location-based-routing) governing the order fulfillment location assignment.
 
 ``` mermaid
 flowchart TD

--- a/content/docs/storefront/themes/guides/product-metadata.md
+++ b/content/docs/storefront/themes/guides/product-metadata.md
@@ -5,7 +5,7 @@ tags:
  - Guide
 ---
 
-Product metadata lets you add custom data for products to use in theme templates. This provides a robust structured way for theme developers to customize products display in the storefront. [See our user guide on adding custom metadata fields](https://docs.29next.com/build-a-store/technical-settings/metadata-fields).
+Product metadata lets you add custom data for products to use in theme templates. This provides a robust structured way for theme developers to customize products display in the storefront. [See our user guide on adding custom metadata fields](https://docs.nextcommerce.com/docs/build-a-store/technical-settings/metadata-fields-and-tags).
 
 
 ### Template Access
@@ -37,5 +37,4 @@ In your theme's product template, add the code below to render the tagline by ac
 **Add Tagline Value to Product**
 
 In your product metadata settings, add your tagline field with a value to render the your storefront product details. :clap:
-
 


### PR DESCRIPTION
## Summary
- replace stale docs.29next.com links with docs.nextcommerce.com equivalents
- update moved metadata field URLs to the current metadata-fields-and-tags page
- confirm docs repo has no remaining docs.29next.com references

## Validation
- rg scan across developer-docs worktree and docs repo found no remaining docs.29next.com references
- confirmed mapped docs source files exist in NextCommerceCo/docs
- curl -I returned HTTP 200 for all replacement docs.nextcommerce.com URLs