### PR TITLE
Remove limos from public template gallery + reframe generic guide

### DIFF
--- a/components/campaign-templates-grid.tsx
+++ b/components/campaign-templates-grid.tsx
@@ -81,22 +81,6 @@ const TEMPLATES: CampaignTemplate[] = [
     ],
   },
   {
-    name: 'limos',
-    slug: 'limos',
-    description:
-      'Quantity-tier campaigns ("buy 1 / 3 / 6") with the bundle selector on the checkout page itself.',
-    link: `${BASE}/limos/checkout/`,
-    page_links: [
-      { label: 'Presell', url: `${BASE}/limos/presell/` },
-      { label: 'Landing', url: `${BASE}/limos/landing/` },
-      { label: 'Checkout', url: `${BASE}/limos/checkout/` },
-      { label: 'Upsell — stepper', url: `${BASE}/limos/upsell-bundle-stepper/` },
-      { label: 'pills', url: `${BASE}/limos/upsell-bundle-tier-pills/` },
-      { label: 'cards', url: `${BASE}/limos/upsell-bundle-tier-cards/` },
-      { label: 'Receipt', url: `${BASE}/limos/receipt/` },
-    ],
-  },
-  {
     name: 'shop-single-step',
     slug: 'shop-single-step',
     description: 'Shopify-style single-step layout — familiar ecommerce feel.',

--- a/content/docs/campaigns/guides/quantity-package-swapper.md
+++ b/content/docs/campaigns/guides/quantity-package-swapper.md
@@ -35,7 +35,7 @@ Quantity in cart matches selector quantity:
 
 ```javascript
 const QUANTITY_MAPS = {
-  'limos-card': {
+  'product-card': {
     1: 2,   // Selector qty 1 → Package 2, cart qty 1
     2: 3,   // Selector qty 2 → Package 3, cart qty 2
     3: 4,   // Selector qty 3 → Package 4, cart qty 3
@@ -48,7 +48,7 @@ Specify different quantity in cart:
 
 ```javascript
 const QUANTITY_MAPS = {
-  'limos-card': {
+  'product-card': {
     1: { packageId: 2, quantity: 1 },   // Selector qty 1 → Package 2, cart qty 1
     2: { packageId: 3, quantity: 5 },   // Selector qty 2 → Package 3, cart qty 5
     3: { packageId: 4, quantity: 10 },  // Selector qty 3 → Package 4, cart qty 10
@@ -61,7 +61,7 @@ Add multiple packages to cart:
 
 ```javascript
 const QUANTITY_MAPS = {
-  'limos-card': {
+  'product-card': {
     1: 2,   // Simple format
     2: { packageId: 3, quantity: 3 },  // Custom quantity
     3: [    // Multiple packages!
@@ -103,7 +103,7 @@ Uses **custom `data-qty-*` attributes** to avoid conflicts with SDK's native sel
 
 ```html
 <!-- Custom quantity selector (independent from SDK selectors) -->
-<div data-qty-selector="limos-card">
+<div data-qty-selector="product-card">
 
   <div data-qty-card
        data-next-package-id="2"
@@ -183,7 +183,7 @@ The script exposes a global API for manual control:
 
 ```javascript
 // Manually sync a selector from cart
-QuantityPackageSwapper.syncSelectorFromCart('limos-card');
+QuantityPackageSwapper.syncSelectorFromCart('product-card');
 
 // Sync all selectors
 QuantityPackageSwapper.syncAllSelectorsFromCart();
@@ -289,7 +289,7 @@ const CONFIG = {
 <body>
 
   <!-- Custom quantity selector -->
-  <div data-qty-selector="limos-card">
+  <div data-qty-selector="product-card">
     <div data-qty-card
          data-next-package-id="2"
          data-qty-current="1"
@@ -316,7 +316,7 @@ const CONFIG = {
       'use strict';
 
       const QUANTITY_MAPS = {
-        'limos-card': {
+        'product-card': {
           1: 2,
           2: 3,
           3: 4,


### PR DESCRIPTION
Part of the limos privatization wave — limos moves to private `Sellmore-Co/adsbranded-templates`.

- **`components/campaign-templates-grid.tsx`** — remove the limos entry from the public template-family gallery. Its demo links pointed at `nextcommerce-campaign-templates.netlify.app/limos/*` previews that disappear once **campaign-cart-starter-templates #102** removes the source. Private families (e.g. arjuna) are already absent from this gallery — same treatment.
- **`content/docs/campaigns/guides/quantity-package-swapper.md`** — this is a **generic** feature guide that merely used `'limos-card'` as its example `data-qty-selector` / config key. Renamed all 7 example occurrences to `'product-card'` rather than deleting the guide — no limos-only behavior is documented.

Left as-is: `public/assets/css/next-core.css` structural `.cc-limos__qty` / `.cc-bump-limos` selectors (shared checkout core; harmless dead CSS).

Part of the wave: adsbranded #14 → campaigns-os #136 → #137, starter-templates #102, next-campaigns-ops #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)